### PR TITLE
Version info file to indicate new game releases

### DIFF
--- a/ver_info.nfo
+++ b/ver_info.nfo
@@ -1,0 +1,3 @@
+(supertux-versioninfo
+  (latest "0.6.3")
+)


### PR DESCRIPTION
Adds a new file to this repository, which will indicate the latest release of SuperTux. It has to be updated on each new release, otherwise the feature, proposed by SuperTux/supertux#2267, wouldn't function properly.

Related to SuperTux/supertux#2267.